### PR TITLE
Remove feedback integration from Sentry configuration

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,11 +18,6 @@ Sentry.init({
   integrations: [
     Sentry.browserTracingIntegration(),
     Sentry.replayIntegration(),
-    Sentry.feedbackIntegration({
-      colorScheme: 'system',
-      isEmailRequired: true,
-      showBranding: false,
-    }),
   ],
   tracesSampleRate: 1.0,
   tracePropagationTargets: ['localhost'],

--- a/vite.config.js
+++ b/vite.config.js
@@ -19,6 +19,7 @@ export default defineConfig(({ mode }) => {
       'process.env.PROXY_SERVER2_URL': JSON.stringify(env.PROXY_SERVER2_URL),
       'process.env.ENVIORNMENT': JSON.stringify(env.ENVIORNMENT),
       'process.env.AUTH_SERVICE_URL': JSON.stringify(env.AUTH_SERVICE_URL),
+      __APP_VERSION__: JSON.stringify(require('./package.json').version),
     },
     build: {
       sourcemap: true,


### PR DESCRIPTION
Eliminate the feedback integration from the Sentry setup to streamline the configuration.