### PR TITLE
Feature/integration phantom wallet

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@bonfida/spl-name-service": "^3.0.7",
     "@dialectlabs/blinks": "0.18.3",
     "@microsoft/clarity": "^1.0.0",
+    "@phantom/wallet-sdk": "^0.0.23",
     "@privy-io/react-auth": "^2.2.1",
     "@sentry/react": "^8.47.0",
     "@sentry/vite-plugin": "^2.22.7",

--- a/src/components/wallet/WalletPicker.tsx
+++ b/src/components/wallet/WalletPicker.tsx
@@ -110,7 +110,9 @@ export const WalletPicker: FC<WalletPickerProps> = ({
             'flex items-center justify-center w-full p-4 bg-surface rounded-xl gap-x-2 border-[2px] border-border'
           }
           onClick={() => {
-            connectWallet();
+            connectWallet({
+              walletList: ['phantom', 'solflare'],
+            });
           }}
         >
           <Link size={24} className="text-textColor text-md" />

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -70,6 +70,7 @@ const RootApp = () => {
               accentColor: theme.primary || '#1D1D1F',
               logo: '/sola_black_logo.svg',
               showWalletLoginFirst: true,
+              walletChainType: 'solana-only',
             },
           }}
         >

--- a/src/models/ThemeManager.ts
+++ b/src/models/ThemeManager.ts
@@ -134,7 +134,7 @@ const ThemeHandler: StateCreator<ThemeStore> = (set, get) => {
 
     setTheme: (theme: Theme) => {
       // check if the theme exists just in case or default to the light theme
-      if (!get().availableThemes[theme.name]) {
+      if (!get().availableThemes[theme?.name]) {
         theme = get().availableThemes['light'];
       }
       set({ theme });

--- a/src/models/WalletHandler.ts
+++ b/src/models/WalletHandler.ts
@@ -43,7 +43,9 @@ interface WalletHandler {
   setWallets: (
     wallets: (ConnectedSolanaWallet | ConnectedPhantomEmbeddedWallet)[],
   ) => void; // Updates available wallets
-  setCurrentWallet: (wallet: ConnectedSolanaWallet | null) => void; // Updates current wallet
+  setCurrentWallet: (
+    wallet: ConnectedSolanaWallet | ConnectedPhantomEmbeddedWallet | null,
+  ) => void; // Allow both wallet types
   setDefaultWallet: (wallet: ConnectedSolanaWallet | null) => void; // Updates default wallet
 
   initWalletManager: () => void; // Initializes the wallet manager

--- a/src/models/WalletHandler.ts
+++ b/src/models/WalletHandler.ts
@@ -216,7 +216,8 @@ export const useWalletHandler = create<WalletHandler>((set, get) => {
     /**
      * Initializes the wallet manager by loading the default wallet from localStorage.
      */
-    initWalletManager: () => {
+    initWalletManager: async () => {
+      const phantom = await createPhantom();
       const defaultWalletAddress = localStorage.getItem('defaultWallet');
       if (defaultWalletAddress) {
         const wallet = get().wallets.find(
@@ -250,7 +251,6 @@ export const useWalletHandler = create<WalletHandler>((set, get) => {
       const phantomWallet: ConnectedPhantomEmbeddedWallet = {
         address: '', // Set the address after connecting
         signTransaction: async (transaction) => {
-          const phantom = await createPhantom();
           return await phantom.solana.signAndSendTransaction(transaction);
         },
         walletClientType: 'phantom',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1978,6 +1978,11 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@phantom/wallet-sdk@^0.0.23":
+  version "0.0.23"
+  resolved "https://registry.yarnpkg.com/@phantom/wallet-sdk/-/wallet-sdk-0.0.23.tgz#9ac8df857734096a103604f8e31d243eeb9efd52"
+  integrity sha512-uwmUUAIzdNK1jT4LpJaXDnnyzohqMehwFjBv+VLSGAxtoaqnhl4MSBQ76n2jfXJEctEUND24FGBOpw+787cJZA==
+
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"


### PR DESCRIPTION
- Create a new interface name ConnectedPhantomEmbeddedWallet with these requirements in the image below

- Add a new type to differentiate b/w privy connected wallets and this wallet

- Add this embedded wallet the the wallets array. so user can switch b/w privy connected wallets and this wallet

- Add support in existing tools to perform tx or other actions when this wallet is selected as current wallet.